### PR TITLE
Added support for auto pagination

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -2,6 +2,7 @@
 
 use Arcanedev\Stripe\Contracts\CollectionInterface;
 use Arcanedev\Stripe\Exceptions\ApiException;
+use Arcanedev\Stripe\Utilities\AutoPagingIterator;
 use Arcanedev\Stripe\Utilities\Util;
 
 /**
@@ -18,6 +19,26 @@ use Arcanedev\Stripe\Utilities\Util;
  */
 class Collection extends StripeResource implements CollectionInterface
 {
+    /* ------------------------------------------------------------------------------------------------
+     |  Properties
+     | ------------------------------------------------------------------------------------------------
+     */
+    protected $requestParams = [];
+
+    /* ------------------------------------------------------------------------------------------------
+     |  Getters & Setters
+     | ------------------------------------------------------------------------------------------------
+     */
+    /**
+     * Set the request parameters.
+     *
+     * @param  array  $params
+     */
+    public function setRequestParams($params)
+    {
+        $this->requestParams = $params;
+    }
+
     /* ------------------------------------------------------------------------------------------------
      |  CRUD Functions
      | ------------------------------------------------------------------------------------------------
@@ -69,6 +90,8 @@ class Collection extends StripeResource implements CollectionInterface
         $extn                  = urlencode(str_utf8($id));
         list($response, $opts) = $this->request('get', "$url/$extn", $params);
 
+        $this->setRequestParams($params);
+
         return Util::convertToStripeObject($response, $opts);
     }
 
@@ -86,7 +109,21 @@ class Collection extends StripeResource implements CollectionInterface
         list($url, $params)    = $this->extractPathAndUpdateParams($params);
         list($response, $opts) = $this->request($method, $url, $params, $options);
 
+        $this->setRequestParams($params);
+
         return Util::convertToStripeObject($response, $opts);
+    }
+
+    /**
+     * Get An iterator that can be used to iterate across all objects across all pages.
+     *     As page boundaries are encountered, the next page will be fetched automatically
+     *     for continued iteration.
+     *
+     * @return \Arcanedev\Stripe\Utilities\AutoPagingIterator
+     */
+    public function autoPagingIterator()
+    {
+        return AutoPagingIterator::make($this, $this->requestParams);
     }
 
     /* ------------------------------------------------------------------------------------------------

--- a/src/StripeObject.php
+++ b/src/StripeObject.php
@@ -6,6 +6,7 @@ use Arcanedev\Stripe\Contracts\Utilities\Jsonable;
 use Arcanedev\Stripe\Exceptions\ApiException;
 use Arcanedev\Stripe\Exceptions\InvalidArgumentException;
 use Arcanedev\Stripe\Http\RequestOptions;
+use Arcanedev\Stripe\Http\Response;
 use Arcanedev\Stripe\Utilities\Util;
 use Arcanedev\Stripe\Utilities\UtilSet;
 use ArrayAccess;
@@ -177,15 +178,17 @@ class StripeObject implements ObjectInterface, ArrayAccess, JsonSerializable, Ar
      *
      * @return mixed|null
      */
-    public function __get($key)
+    public function &__get($key)
     {
+        $nullVal = null;
+
         if (in_array($key, $this->keys())) {
             return $this->values[$key];
         }
 
         $this->showUndefinedPropertyMsg(get_class($this), $key);
 
-        return null;
+        return $nullVal;
     }
 
     /**
@@ -249,7 +252,7 @@ class StripeObject implements ObjectInterface, ArrayAccess, JsonSerializable, Ar
      *
      * @return self
      */
-    public function setLastResponse(\Arcanedev\Stripe\Http\Response $response)
+    public function setLastResponse(Response $response)
     {
         $this->lastResponse = $response;
 

--- a/src/Utilities/AutoPagingIterator.php
+++ b/src/Utilities/AutoPagingIterator.php
@@ -1,0 +1,133 @@
+<?php namespace Arcanedev\Stripe\Utilities;
+
+use Arcanedev\Stripe\Collection;
+use Iterator;
+
+/**
+ * Class     AutoPagingIterator
+ *
+ * @package  Arcanedev\Stripe\Utilities
+ * @author   ARCANEDEV <arcanedev.maroc@gmail.com>
+ */
+class AutoPagingIterator implements Iterator
+{
+    /* ------------------------------------------------------------------------------------------------
+     |  Properties
+     | ------------------------------------------------------------------------------------------------
+     */
+    private $lastId = null;
+
+    /** @var \Arcanedev\Stripe\Collection  */
+    private $page   = null;
+
+    /** @var array */
+    private $params = [];
+
+    /* ------------------------------------------------------------------------------------------------
+     |  Constructor
+     | ------------------------------------------------------------------------------------------------
+     */
+    /**
+     * AutoPagingIterator constructor.
+     *
+     * @param  \Arcanedev\Stripe\Collection  $collection
+     * @param  array                         $params
+     */
+    public function __construct(Collection $collection, array $params)
+    {
+        $this->page   = $collection;
+        $this->params = $params;
+    }
+
+    /**
+     * Make a AutoPagingIterator object.
+     *
+     * @param  \Arcanedev\Stripe\Collection  $collection
+     * @param  array                         $params
+     *
+     * @return self
+     */
+    public static function make(Collection $collection, array $params)
+    {
+        return new self($collection, $params);
+    }
+
+    /* ------------------------------------------------------------------------------------------------
+     |  Main Functions
+     | ------------------------------------------------------------------------------------------------
+     */
+    /**
+     * Return the current element.
+     * @link  http://php.net/manual/en/iterator.current.php
+     *
+     * @return mixed
+     */
+    public function current()
+    {
+        $item         = current($this->page->data);
+        $this->lastId = $item !== false ? $item['id'] : null;
+
+        return $item;
+    }
+
+    /**
+     * Move forward to next element.
+     * @link  http://php.net/manual/en/iterator.next.php
+     *
+     * @return void
+     */
+    public function next()
+    {
+        $item = next($this->page->data);
+
+        if ($item === false) {
+            // If we've run out of data on the current page, try to fetch another one
+            if ($this->page['has_more']) {
+                $this->params = array_merge(
+                    $this->params ? $this->params : [],
+                    ['starting_after' => $this->lastId]
+                );
+
+                $this->page   = $this->page->all($this->params);
+            }
+            else {
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Return the key of the current element.
+     * @link  http://php.net/manual/en/iterator.key.php
+     *
+     * @return mixed
+     */
+    public function key()
+    {
+        return key($this->page->data);
+    }
+
+    /**
+     * Checks if current position is valid.
+     * @link  http://php.net/manual/en/iterator.valid.php
+     *
+     * @return bool
+     */
+    public function valid()
+    {
+        $key  = key($this->page->data);
+
+        return ($key !== null && $key !== false);
+    }
+
+    /**
+     * Rewind the Iterator to the first element.
+     * @link  http://php.net/manual/en/iterator.rewind.php
+     *
+     * @return void
+     */
+    public function rewind()
+    {
+        // Actually rewinding would require making a copy of the original page.
+    }
+}

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1,0 +1,99 @@
+<?php namespace Arcanedev\Stripe\Tests;
+use Arcanedev\Stripe\Collection;
+use Arcanedev\Stripe\Http\RequestOptions;
+
+/**
+ * Class     CollectionTest
+ *
+ * @package  Arcanedev\Stripe\Tests
+ * @author   ARCANEDEV <arcanedev.maroc@gmail.com>
+ */
+class CollectionTest extends StripeTestCase
+{
+    /* ------------------------------------------------------------------------------------------------
+     |  Test Functions
+     | ------------------------------------------------------------------------------------------------
+     */
+    /** @test */
+    public function it_can_auto_paging_one_page()
+    {
+        /** @var Collection $collection */
+        $collection = Collection::scopedConstructFrom(
+            'Arcanedev\Stripe\Collection',
+            $this->pageableModelResponse(['pm_123', 'pm_124'], false),
+            new RequestOptions
+        );
+
+        $seen = [];
+
+        foreach ($collection->autoPagingIterator() as $item) {
+            array_push($seen, $item['id']);
+        }
+
+        $this->assertEquals(['pm_123', 'pm_124'], $seen);
+    }
+
+    /** @test */
+    public function it_can_auto_paging_three_pages()
+    {
+        /** @var Collection $collection */
+        $collection = Collection::scopedConstructFrom(
+            'Arcanedev\Stripe\Collection',
+            $this->pageableModelResponse(['pm_123', 'pm_124'], true),
+            new RequestOptions
+        );
+
+        $collection->setRequestParams(['foo' => 'bar']);
+
+        $this->mockRequest(
+            'GET',
+            '/v1/pageablemodels',
+            [
+                'foo'            => 'bar',
+                'starting_after' => 'pm_124'
+            ],
+            $this->pageableModelResponse(['pm_125', 'pm_126'], true)
+        );
+
+        $this->mockRequest(
+            'GET',
+            '/v1/pageablemodels',
+            [
+                'foo'            => 'bar',
+                'starting_after' => 'pm_126'
+            ],
+            $this->pageableModelResponse(['pm_127'], false)
+        );
+
+        $seen = [];
+
+        foreach ($collection->autoPagingIterator() as $item) {
+            array_push($seen, $item['id']);
+        }
+
+        $this->assertEquals(['pm_123', 'pm_124', 'pm_125', 'pm_126', 'pm_127'], $seen);
+    }
+
+    /* ------------------------------------------------------------------------------------------------
+     |  Other Functions
+     | ------------------------------------------------------------------------------------------------
+     */
+    private function pageableModelResponse($ids, $hasMore)
+    {
+        $data = [];
+
+        foreach ($ids as $id) {
+            array_push($data, [
+                'id'     => $id,
+                'object' => 'pageablemodel'
+            ]);
+        }
+
+        return [
+            'object'   => 'list',
+            'url'      => '/v1/pageablemodels',
+            'data'     => $data,
+            'has_more' => $hasMore
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds support for auto pagination. The following code:

``` php
$charges = \Stripe\Charge::all();
foreach ($charges->autoPagingIterator() as $charge) {
    // Do something with $charge
}
```

It will iterate over all charges. No more need to fiddle with pagination parameters !
