### PR TITLE
Set the stripe_account globaly when working on managed account

### DIFF
--- a/src/Http/Curl/HeaderBag.php
+++ b/src/Http/Curl/HeaderBag.php
@@ -57,6 +57,10 @@ class HeaderBag implements HeaderBagInterface
             $defaults['Stripe-Version'] = Stripe::getApiVersion();
         }
 
+        if (Stripe::hasAccountId()) {
+            $defaultHeaders['Stripe-Account'] = Stripe::getAccountId();
+        }
+
         return $defaults;
     }
 

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -56,6 +56,13 @@ abstract class Stripe implements StripeInterface
     public static $apiVersion    = null;
 
     /**
+     * The account ID for connected accounts requests.
+     *
+     * @var string|null
+     */
+    public static $accountId     = null;
+
+    /**
      * Verify SSL Certs
      *
      * @var bool
@@ -170,6 +177,26 @@ abstract class Stripe implements StripeInterface
         self::checkApiVersion($apiVersion);
 
         self::$apiVersion = $apiVersion;
+    }
+
+    /**
+     * Get the Stripe account ID for connected accounts requests.
+     *
+     * @return string|null
+     */
+    public static function getAccountId()
+    {
+        return self::$accountId;
+    }
+
+    /**
+     * Set the Stripe account ID to set for connected accounts requests.
+     *
+     * @param  string  $accountId
+     */
+    public static function setAccountId($accountId)
+    {
+        self::$accountId = $accountId;
     }
 
     /**
@@ -325,5 +352,15 @@ abstract class Stripe implements StripeInterface
     public static function hasApiVersion()
     {
         return ! empty(self::$apiVersion);
+    }
+
+    /**
+     * Check if the Stripe has account ID for connected accounts requests.
+     *
+     * @return bool
+     */
+    public static function hasAccountId()
+    {
+        return ! empty(self::$accountId);
     }
 }

--- a/tests/StripeTest.php
+++ b/tests/StripeTest.php
@@ -31,6 +31,20 @@ class StripeTest extends StripeTestCase
         $this->assertEquals($this->myApiKey, Stripe::getApiKey());
     }
 
+    /** @test */
+    public function it_can_get_and_set_account_id()
+    {
+        $accountId = 'stripe_account_id';
+
+        $this->assertFalse(Stripe::hasAccountId());
+        $this->assertNull(Stripe::getAccountId());
+
+        Stripe::setAccountId($accountId);
+
+        $this->assertTrue(Stripe::hasAccountId());
+        $this->assertEquals($accountId, Stripe::getAccountId());
+    }
+
     /**
      * @test
      *


### PR DESCRIPTION
This will automatically add Stripe-Account header and the value if the `Stripe::setAccountId($accountId)` has been used.

This can be very useful if you set your api key with a service provider, and have to deal with managed accounts on many requests.
